### PR TITLE
Replace fetch with Axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "Carl Smith <5456533+CarlosNZ@users.noreply.github.com>",
   "license": "MIT",
   "dependencies": {
+    "axios": "^0.21.1",
     "checkdigit": "^1.1.1",
     "lodash": "^4.17.21",
     "randexp": "^0.5.3"
@@ -20,7 +21,6 @@
     "@types/lodash": "^4.14.171",
     "@types/node-fetch": "^2.5.11",
     "jest": "^27.0.6",
-    "node-fetch": "^2.6.1",
     "ts-jest": "^27.0.3",
     "ts-node": "^10.0.0",
     "typescript": "^4.3.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom_string_patterns",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Generate random and incrementing string patterns using regex and custom functions",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,5 +1,5 @@
 import Pattern from './patterns'
-import fetch from 'node-fetch'
+import axios from 'axios'
 import { generatePlates } from './customCounters'
 const checkdigit = require('checkdigit')
 
@@ -19,8 +19,8 @@ const showBasicPattern = async () => {
 
 // Function to fetch an item from an online API
 const getAlbumString = async (key: number) => {
-  const data = await fetch('https://jsonplaceholder.typicode.com/albums')
-  return (await data.json())[key].title
+  const response = await axios.get('https://jsonplaceholder.typicode.com/albums')
+  return response.data[key].title
 }
 
 // More complex pattern with 2 custom replacers and a Intl formatted counter, and a non-standard incrementing function

--- a/src/patterns.test.ts
+++ b/src/patterns.test.ts
@@ -1,5 +1,5 @@
+import axios from 'axios'
 import Pattern, { patternGen } from './patterns'
-import fetch from 'node-fetch'
 import { generatePlates } from './customCounters'
 const checkdigit = require('checkdigit')
 
@@ -72,8 +72,8 @@ test('Shorthand version of basicPattern2', () => {
 
 // Function to fetch an item from an online API
 const getAlbumString = async (key: number) => {
-  const data = await fetch('https://jsonplaceholder.typicode.com/albums')
-  return (await data.json())[key].title
+  const response = await axios('https://jsonplaceholder.typicode.com/albums')
+  return response.data[key].title
 }
 
 // More complex pattern with 2 custom replacers and a Intl formatted counter, and a non-standard incrementing function
@@ -219,8 +219,8 @@ test('Shorthand version of separated methods', () => {
 
 // Using a Unix timestamp as a custom replacment
 const getTimestamp = async () => {
-  const data = await fetch('https://showcase.api.linx.twenty57.net/UnixTime/tounix?date=now')
-  return await data.json()
+  const response = await axios('https://showcase.api.linx.twenty57.net/UnixTime/tounix?date=now')
+  return response.data
 }
 
 const timestampPattern = new Pattern('[A-z0-9!@#$%^&]{8}-<?timestamp>', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,6 +742,13 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 babel-jest@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.0.6.tgz#e99c6e0577da2655118e3608b68761a5a69bd0d8"
@@ -1206,6 +1213,11 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+follow-redirects@^1.10.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
+  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
 
 form-data@^3.0.0:
   version "3.0.1"
@@ -2041,11 +2053,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-
-node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Tests/demo were using "node-fetch" for GET requests. This meant it would fail when run in the browser, since browser uses native fetch.

Replaced all usage of fetch with axios so it works the same whether run from node or browser.