### PR TITLE
Replace lookaheads/behinds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom_string_patterns",
-  "version": "0.5.0",
+  "version": "0.5.5",
   "description": "Generate random and incrementing string patterns using regex and custom functions",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -3,50 +3,15 @@ This file used as a playground for development. It is not published in the actua
 */
 
 import Pattern, { patternGen } from './patterns'
-import fetch from 'node-fetch'
-const checkdigit = require('checkdigit')
 
-// Function to fetch an item from an online API
-const getAlbumString = async (key: number) => {
-  const data = await fetch('https://jsonplaceholder.typicode.com/albums')
-  return (await data.json())[key].title
-}
+// const basicPattern = new Pattern(/.{10}-<+ddd>/i)
 
-const basicPattern = new Pattern(/.{100}/i)
+// basicPattern.gen().then((res) => console.log(res))
 
-basicPattern.gen().then((res) => console.log(res))
+// const patternWithLiterals = new Pattern(/\<1\>-[A-Z]{3}-<+dd>-<?f1>/, {
+//   customReplacers: { f1: () => 'Testing' },
+// })
 
-const fancyPattern = new Pattern(/Album name: <?album>, serial: [A-Z]{3}_<+d> \(<?upper>\)/, {
-  counterInit: 5000,
-  counterIncrement: (prev) => Number(prev) + 100,
-  customReplacers: {
-    album: getAlbumString,
-    upper: (str: string) => str.toUpperCase(),
-  },
-  numberFormat: new Intl.NumberFormat('en-US'),
-})
+// patternWithLiterals.gen().then((res) => console.log(res))
 
-fancyPattern
-  .gen({
-    customArgs: {
-      album: 10,
-      upper: '_end',
-    },
-  })
-  .then((res) => console.log(res))
-
-const dynamicArgPattern = new Pattern(/([a-z]{3,6})-(test)-<+ddd>-<?upper(1, 2)>-<?lower>/, {
-  customReplacers: {
-    upper: (...args: string[]) => args.join('').toUpperCase(),
-    lower: (chars: string) => chars.toLowerCase(),
-  },
-})
-
-const showDynamicArgPattern = async () => {
-  console.log('Testing passing capture groups to customReplacers')
-  for (let i = 1; i < 12; i++) {
-    console.log('Output:', await dynamicArgPattern.gen({ customArgs: { lower: 'SomThiNG' } }))
-  }
-}
-
-showDynamicArgPattern()
+patternGen(/Another\<<+dd>-\>\>_<+dddd>_DONE/).then((res) => console.log(res))

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,7 +8,11 @@ export const processInputPattern = (pattern: string | RegExp, randexpOptions: Ra
   const { source, flags } = patternRegex
   const substitionMap: SubstitutionMap = {}
   let randexpPattern = source
-  const matches = Array.from(source.matchAll(/(?<!\\)<(.+?)(?<!\\)>/g)).entries()
+    // Replace escaped "<" and ">" with "magic strings" to so they won't
+    // interfere with subsequent replacements
+    .replace(/\\</g, ESCAPED_OPEN_ANGLE_BRACKET)
+    .replace(/\\>/g, ESCAPED_CLOSE_ANGLE_BRACKET)
+  const matches = Array.from(randexpPattern.matchAll(/<(.+?)>/g)).entries()
   for (const [index, match] of Array.from(matches)) {
     const fullMatchString = match[0]
     const captureGroup = match[1]
@@ -24,10 +28,6 @@ export const processInputPattern = (pattern: string | RegExp, randexpOptions: Ra
     }
     randexpPattern = randexpPattern.replace(fullMatchString, `<${index}>`)
   }
-  // Replace literal backslashes with "magic strings" to preserve through so they don't get replaced by subsequent replacements
-  randexpPattern = randexpPattern
-    .replace(/\\</g, ESCAPED_OPEN_ANGLE_BRACKET)
-    .replace(/\\>/g, ESCAPED_CLOSE_ANGLE_BRACKET)
 
   // Create RandExp object and apply options
   const randexpObject = new RandExp(randexpPattern, flags)

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -141,10 +141,7 @@ class PatternGenerator {
           numberFormat: this.numberFormat,
           length: counter?.length || 0,
         })
-        outputString = outputString.replace(
-          new RegExp(`(?<!\\\\)<${index}(?<!\\\\)>`),
-          formattedCounter
-        )
+        outputString = outputString.replace(new RegExp(`<${index}>`), formattedCounter)
       }
     })
 
@@ -160,10 +157,7 @@ class PatternGenerator {
     })
     const functionResults = await Promise.all(functionResultPromises) // for async functions
     functions.forEach(([index, _], i) => {
-      outputString = outputString.replace(
-        new RegExp(`(?<!\\\\)<${index}(?<!\\\\)>`),
-        functionResults[i]
-      )
+      outputString = outputString.replace(new RegExp(`<${index}>`), functionResults[i])
     })
 
     // Extract data properties
@@ -172,7 +166,7 @@ class PatternGenerator {
       if ('property' in propertyObj) {
         const { property } = propertyObj
         outputString = outputString.replace(
-          new RegExp(`(?<!\\\\)<${index}(?<!\\\\)>`),
+          new RegExp(`<${index}>`),
           extractObjectProperty(data, property as string, this.fallbackString)
         )
       }


### PR DESCRIPTION
Turns out Safari (and IE but who cares about that) doesn't support lookbehinds in Regexes, so wasn't able to use properly in a browser app.

https://caniuse.com/js-regexp-lookbehind

Have replaced these regexes and in the process simplified the matching and replacement regexes (by putting magic strings for escaped `<` and `>` at the start of the pattern building process rather than the end.