### PR TITLE
Improve state updates with large iterations

### DIFF
--- a/demo/src/examples.tsx
+++ b/demo/src/examples.tsx
@@ -40,7 +40,7 @@ pattern.gen()`,
           getCounter
         </Text>{' '}
         method uses a counter from an external database so its value is persisted independently of
-        this module.
+        this particular instance.
       </span>
     ),
     pattern: /Count: <+dddd>/,
@@ -64,7 +64,6 @@ pattern.gen()`,
     options: { getCounter: () => plates.next() },
     resetCounterMethod: (newStartVal: string) => (plates = generatePlates(newStartVal)),
     counterInputInit: 'AAA100',
-    hideCounterReset: true,
     codeStringTemplate: `// Custom plate number-generating function
   const plates = generatePlates("\${counterInit}") // defined elsewhere
 
@@ -202,6 +201,7 @@ pattern.gen()`,
         whichCard: cardTypeLookup,
       },
     },
+    hideCounterReset: true,
     codeStringTemplate: `// Function to create a single-digit checksum that makes the whole number valid
   // Uses https://www.npmjs.com/package/checkdigit
   const generateChecksum = (digits) =>


### PR DESCRIPTION
Added setInterval to update the output state once per second rather than after every generator iteration. 

This prevents the "Maximum update depth exceeded" React error for fast (i.e. internal counter) generators.

But if we wait till all iterations are complete, then slow generators (e.g. database queries) have no UI update until all iterations are complete.

So we update periodically so we get UI updates for slow ones, but fast ones do all output state updates at once.
